### PR TITLE
hotfix: SQL 트랜잭션을 분리해놓은 서비스를 하나의 트랜잭션으로 합침

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,9 @@ dependencies {
     //LOGGING
     implementation("ca.pjer:logback-awslogs-appender:1.6.0")
 
+    //configuration processor
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/src/main/kotlin/swyg/hollang/HollangApplication.kt
+++ b/src/main/kotlin/swyg/hollang/HollangApplication.kt
@@ -1,9 +1,11 @@
 package swyg.hollang
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 import org.springframework.cloud.openfeign.EnableFeignClients
 
+@ConfigurationPropertiesScan("swyg.hollang.config")
 @EnableFeignClients
 @SpringBootApplication
 class HollangApplication

--- a/src/main/kotlin/swyg/hollang/config/FeignClientConfig.kt
+++ b/src/main/kotlin/swyg/hollang/config/FeignClientConfig.kt
@@ -1,0 +1,20 @@
+package swyg.hollang.config
+
+import feign.Request
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.util.concurrent.TimeUnit
+
+@Configuration
+class FeignClientConfig(val feignClientConfigProperties: FeignClientConfigProperties) {
+
+    //타임아웃시 최대한 빨리 오류를 발생시켜 롤백을 하기 위함
+    @Bean
+    fun requestOptions(): Request.Options {
+        return Request.Options(
+            feignClientConfigProperties.connectTimeout,
+            TimeUnit.MILLISECONDS,
+            feignClientConfigProperties.readTimeout,
+            TimeUnit.MILLISECONDS, false)
+    }
+}

--- a/src/main/kotlin/swyg/hollang/config/FeignClientConfigProperties.kt
+++ b/src/main/kotlin/swyg/hollang/config/FeignClientConfigProperties.kt
@@ -1,0 +1,9 @@
+package swyg.hollang.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("feign.client.config.default")
+class FeignClientConfigProperties {
+    var connectTimeout: Long = 5000
+    var readTimeout: Long = 10000
+}

--- a/src/main/kotlin/swyg/hollang/controller/RecommendationController.kt
+++ b/src/main/kotlin/swyg/hollang/controller/RecommendationController.kt
@@ -5,43 +5,23 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import swyg.hollang.dto.RecommendHobbyAndTypesResponse
 import swyg.hollang.dto.common.SuccessResponse
-import swyg.hollang.service.HobbyService
-import swyg.hollang.service.HobbyTypeService
-import swyg.hollang.service.RecommendationService
+import swyg.hollang.manager.RecommendationManager
 import swyg.hollang.utils.WebProperties
 
 @RestController
 @RequestMapping("/recommendations")
 @CrossOrigin(origins = ["\${client.server.host}"])
-class RecommendationController(
-    private val recommendationService: RecommendationService,
-    private val hobbyService: HobbyService,
-    private val hobbyTypeService: HobbyTypeService
-) {
+class RecommendationController(private val recommendationManager: RecommendationManager) {
 
     @GetMapping("/{recommendationId}")
     fun recommendHobbyAndTypes(@PathVariable("recommendationId") recommendationId: Long)
         : ResponseEntity<SuccessResponse<RecommendHobbyAndTypesResponse>> {
-        //추천 id로 추천 결과를 가져온다.
-        val findRecommendation = recommendationService.getRecommendationWithUserById(recommendationId)
-        //추천 결과에 해당하는 취미 유형 정보를 가져온다.
-        val recommendedHobbyType = hobbyTypeService
-            .getHobbyTypeByMbtiType((findRecommendation.result!!["hobbyType"] as Map<String, String>)["name"]!!)
-        //추천받은 취미 유형과 잘맞는 유형을 가져온다.
-        val fitHobbyTypes = hobbyTypeService.getHobbyTypesByMbtiTypes(recommendedHobbyType.fitHobbyTypes)
-        //추천받은 취미들의 정보를 가져온다.
-        val hobbyNames = (findRecommendation.result!!["hobbies"] as List<Map<String, String>>).map {
-            it["name"]!!
-        }
-        val recommendedHobbies = hobbyService.getHobbyByName(hobbyNames)
-
+        val recommendHobbyAndTypesResponse = recommendationManager.getUserRecommendation(recommendationId)
         return ResponseEntity.ok()
             .body(SuccessResponse(
                 HttpStatus.OK.name,
                 WebProperties.SUCCESS_RESPONSE_MESSAGE,
-                RecommendHobbyAndTypesResponse(
-                    findRecommendation, recommendedHobbyType, recommendedHobbies, fitHobbyTypes
-                )
+                recommendHobbyAndTypesResponse
             ))
     }
 }

--- a/src/main/kotlin/swyg/hollang/controller/TestResponseController.kt
+++ b/src/main/kotlin/swyg/hollang/controller/TestResponseController.kt
@@ -6,48 +6,28 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import swyg.hollang.dto.CountAllTestResponseResponse
 import swyg.hollang.dto.CreateTestResponseRequest
-import swyg.hollang.dto.CreateTestResponseResponse
-import swyg.hollang.dto.TestDetailsResponse
 import swyg.hollang.dto.common.SuccessResponse
+import swyg.hollang.manager.TestResponseManager
 import swyg.hollang.service.*
 import swyg.hollang.utils.WebProperties
-import java.util.Objects
 
 @RestController
 @RequestMapping("/test-responses")
 @CrossOrigin(origins = ["\${client.server.host}"])
 class TestResponseController(
-    private val userService: UserService,
     private val testResponseService: TestResponseService,
-    private val testResponseDetailService: TestResponseDetailService,
-    private val inferringService: InferringService,
-    private val recommendationService: RecommendationService,
-    private val hobbyService: HobbyService
+    private val testResponseManager: TestResponseManager
 ) {
 
     @PostMapping
     fun createTestResponse(@Valid @RequestBody createTestResponseRequest: CreateTestResponseRequest)
         : ResponseEntity<SuccessResponse<Any>> {
-        //유저 엔티티 생성
-        val createdUser = userService.createUser(createTestResponseRequest.createUserRequest)
-        //테스트 응답 엔티티 생성
-        val createdTestResponse = testResponseService.createTestResponse(createdUser)
-        //테스트 응답 상세정보 엔티티 생성
-        testResponseDetailService.createTestResponseDetail(
-            createdTestResponse, createTestResponseRequest.createTestResponseDetailRequests)
-        //추론 서버에 추론 요청
-        val createRecommendationResultResponse =
-            inferringService.inferHobbiesAndType(createTestResponseRequest.createTestResponseDetailRequests)
-        //추천받은 취미들의 추천수 카운트 증가
-        hobbyService.addHobbiesRecommendCount(createRecommendationResultResponse.hobbies)
-        //추천 엔티티 생성
-        val createdRecommendation = recommendationService.save(createdTestResponse, createRecommendationResultResponse)
-
+        val createTestResponseResponse = testResponseManager.createUserTestResponse(createTestResponseRequest)
         return ResponseEntity.ok()
             .body(SuccessResponse(
                 HttpStatus.OK.name,
                 WebProperties.SUCCESS_RESPONSE_MESSAGE,
-                CreateTestResponseResponse(createdUser, createdRecommendation)))
+                createTestResponseResponse))
     }
 
     @GetMapping("/count")

--- a/src/main/kotlin/swyg/hollang/manager/RecommendationManager.kt
+++ b/src/main/kotlin/swyg/hollang/manager/RecommendationManager.kt
@@ -1,0 +1,36 @@
+package swyg.hollang.manager
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import swyg.hollang.dto.RecommendHobbyAndTypesResponse
+import swyg.hollang.service.HobbyService
+import swyg.hollang.service.HobbyTypeService
+import swyg.hollang.service.RecommendationService
+
+@Component
+class RecommendationManager(
+    private val recommendationService: RecommendationService,
+    private val hobbyService: HobbyService,
+    private val hobbyTypeService: HobbyTypeService
+) {
+
+    @Transactional(readOnly = true)
+    fun getUserRecommendation(recommendationId: Long): RecommendHobbyAndTypesResponse {
+        //추천 id로 추천 결과를 가져온다.
+        val findRecommendation = recommendationService.getRecommendationWithUserById(recommendationId)
+        //추천 결과에 해당하는 취미 유형 정보를 가져온다.
+        val recommendedHobbyType = hobbyTypeService
+            .getHobbyTypeByMbtiType((findRecommendation.result!!["hobbyType"] as Map<String, String>)["name"]!!)
+        //추천받은 취미 유형과 잘맞는 유형을 가져온다.
+        val fitHobbyTypes = hobbyTypeService.getHobbyTypesByMbtiTypes(recommendedHobbyType.fitHobbyTypes)
+        //추천받은 취미들의 정보를 가져온다.
+        val hobbyNames = (findRecommendation.result!!["hobbies"] as List<Map<String, String>>).map {
+            it["name"]!!
+        }
+        val recommendedHobbies = hobbyService.getHobbyByName(hobbyNames)
+
+        return RecommendHobbyAndTypesResponse(
+            findRecommendation, recommendedHobbyType, recommendedHobbies, fitHobbyTypes
+        )
+    }
+}

--- a/src/main/kotlin/swyg/hollang/manager/TestResponseManager.kt
+++ b/src/main/kotlin/swyg/hollang/manager/TestResponseManager.kt
@@ -1,0 +1,38 @@
+package swyg.hollang.manager
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import swyg.hollang.dto.CreateTestResponseRequest
+import swyg.hollang.dto.CreateTestResponseResponse
+import swyg.hollang.service.*
+
+@Component
+class TestResponseManager(
+    private val userService: UserService,
+    private val testResponseService: TestResponseService,
+    private val testResponseDetailService: TestResponseDetailService,
+    private val inferringService: InferringService,
+    private val recommendationService: RecommendationService,
+    private val hobbyService: HobbyService
+) {
+
+    @Transactional
+    fun createUserTestResponse(createTestResponseRequest: CreateTestResponseRequest): CreateTestResponseResponse {
+        //유저 엔티티 생성
+        val createdUser = userService.createUser(createTestResponseRequest.createUserRequest)
+        //테스트 응답 엔티티 생성
+        val createdTestResponse = testResponseService.createTestResponse(createdUser)
+        //테스트 응답 상세정보 엔티티 생성
+        testResponseDetailService.createTestResponseDetail(
+            createdTestResponse, createTestResponseRequest.createTestResponseDetailRequests)
+        //추론 서버에 추론 요청
+        val createRecommendationResultResponse =
+            inferringService.inferHobbiesAndType(createTestResponseRequest.createTestResponseDetailRequests)
+        //추천받은 취미들의 추천수 카운트 증가
+        hobbyService.addHobbiesRecommendCount(createRecommendationResultResponse.hobbies)
+        //추천 엔티티 생성
+        val createdRecommendation = recommendationService.save(createdTestResponse, createRecommendationResultResponse)
+
+        return CreateTestResponseResponse(createdUser, createdRecommendation)
+    }
+}

--- a/src/main/kotlin/swyg/hollang/service/HobbyService.kt
+++ b/src/main/kotlin/swyg/hollang/service/HobbyService.kt
@@ -12,7 +12,6 @@ import swyg.hollang.repository.hobby.HobbyRepository
 class HobbyService(private val hobbyRepository: HobbyRepository) {
 
     //추천받은 취미의 추천 카운트를 1씩 증가
-    @Transactional
     fun addHobbiesRecommendCount(hobbies: MutableList<MutableMap<String, String>>): Int {
         val names = hobbies.map { it["name"]!! }
         return hobbyRepository.updateRecommendCountByName(names)

--- a/src/main/kotlin/swyg/hollang/service/RecommendationApiClient.kt
+++ b/src/main/kotlin/swyg/hollang/service/RecommendationApiClient.kt
@@ -4,10 +4,14 @@ import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import swyg.hollang.config.FeignClientConfig
 import swyg.hollang.dto.CreateRecommendationResultResponse
 import swyg.hollang.dto.CreateTestResponseDetailRequest
 
-@FeignClient(name = "recommendationApiClient", url = "\${inferring.server.host}:5000")
+@FeignClient(
+    name = "recommendationApiClient",
+    url = "\${inferring.server.host}:5000",
+    configuration = [FeignClientConfig::class])
 interface RecommendationApiClient {
 
     @PostMapping("/test-responses", produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/src/main/kotlin/swyg/hollang/service/RecommendationService.kt
+++ b/src/main/kotlin/swyg/hollang/service/RecommendationService.kt
@@ -12,7 +12,6 @@ import swyg.hollang.repository.recommendation.RecommendationRepository
 @Transactional(readOnly = true)
 class RecommendationService(private val recommendationRepository: RecommendationRepository) {
 
-    @Transactional
     fun save(testResponse: TestResponse, createRecommendationResultResponse: CreateRecommendationResultResponse)
         : Recommendation {
         val result = mutableMapOf<String, Any>()

--- a/src/main/kotlin/swyg/hollang/service/TestResponseDetailService.kt
+++ b/src/main/kotlin/swyg/hollang/service/TestResponseDetailService.kt
@@ -16,7 +16,6 @@ class TestResponseDetailService(
     private val answerRepository: AnswerRepository,
     private val testResponseDetailRepository: TestResponseDetailRepository) {
 
-    @Transactional
     fun createTestResponseDetail(
         testResponse: TestResponse,
         createTestResponseDetailRequests: MutableList<CreateTestResponseDetailRequest>): Int {

--- a/src/main/kotlin/swyg/hollang/service/TestResponseService.kt
+++ b/src/main/kotlin/swyg/hollang/service/TestResponseService.kt
@@ -10,7 +10,6 @@ import swyg.hollang.repository.testresponse.TestResponseRepository
 @Transactional(readOnly = true)
 class TestResponseService(private val testResponseRepository: TestResponseRepository) {
 
-    @Transactional
     fun createTestResponse(user: User): TestResponse {
         return testResponseRepository.save(user)
     }

--- a/src/main/kotlin/swyg/hollang/service/UserService.kt
+++ b/src/main/kotlin/swyg/hollang/service/UserService.kt
@@ -10,7 +10,6 @@ import swyg.hollang.repository.user.UserRepository
 @Transactional(readOnly = true)
 class UserService(private val userRepository: UserRepository) {
 
-    @Transactional
     fun createUser(createUserRequest: CreateUserRequest): User {
         return userRepository.save(createUserRequest)
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,3 +33,10 @@ inferring:
 client:
   server:
     host: ${CLIENT_SERVER_HOST}
+
+feign:
+  client:
+    config:
+      default:
+        connectTimeout: 5000
+        readTimeout: 10000


### PR DESCRIPTION
1. 사용자 테스트 응답 만들기를 하나의 트랜잭션으로 합치고, 예외가 발생하면 트랜잭션을 롤백
2. 사용자 추천 홀랑 및 홀랑 유형 조회도 하나의 트랜잭션으로 합침

#18